### PR TITLE
Fixed high score display in main_game.gd

### DIFF
--- a/main_game.gd
+++ b/main_game.gd
@@ -69,7 +69,7 @@ func _on_game_over():
 		config.set_value("score", "highscore", high_score)
 		config.save("user://hscore.cfg")
 
-	end.get_node("Label").text = "Game Over\nScore: " + str(score) + "\n\nHigh Score: " + str(score)
+	end.get_node("Label").text = "Game Over\nScore: " + str(score) + "\n\nHigh Score: " + str(high_score)
 	add_child(end)
 
 	get_tree().paused = true  


### PR DESCRIPTION
You were displaying the high score using the `score` variable instead of `high_score` in main_game.gd. This fixes that.